### PR TITLE
Add tracks to album widget

### DIFF
--- a/app/assets/javascripts/application/flipster.js.coffee
+++ b/app/assets/javascripts/application/flipster.js.coffee
@@ -1,3 +1,8 @@
 $ ->
   # Initialize flipster for an element with an ID of album-coverflow
-  $('#album-coverflow').flipster()
+  flipster = $('#album-coverflow').flipster
+               onItemSwitch: (event) ->
+                 $('#album-tracks').load event.dataset.tracksPath
+
+  # Ajax load the tracks for the album that is selected on page load
+  $('#album-tracks').load $('.flipster__item--current').data 'tracks-path'

--- a/app/assets/stylesheets/albums.scss
+++ b/app/assets/stylesheets/albums.scss
@@ -3,12 +3,14 @@
   color: #FFF;
   text-align: center;
   font-weight: bold;
+  line-height: 23px;
 
   a, a:hover, a:focus {
     color: #FFF;
   }
 
   .back-arrow {
+    line-height: 23px;
     float: left;
   }
 }
@@ -16,4 +18,13 @@
 #album-coverflow {
   background-color: #222;
   color: #FFF;
+}
+
+.album-title {
+  text-align: left;
+  background-color: #D3D3D3;
+}
+
+.track-details {
+  display: inline-block;
 }

--- a/app/assets/stylesheets/main_nav.scss
+++ b/app/assets/stylesheets/main_nav.scss
@@ -36,15 +36,15 @@ input:-ms-input-placeholder {
   outline: none !important;
 }
 
-.Absolute-Center {
+.absolute-center {
   margin: auto;
   position: absolute;
   top: 0; left: 0; bottom: 0; right: 0;
 }
 
-.Absolute-Center.is-Responsive {
+.absolute-center.is-responsive {
   width: 80%;
-  height: 75%;
+  height: 80%;
   min-width: 200px;
   max-width: 1200px;
 }

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,0 +1,7 @@
+class AlbumsController < ApplicationController
+  def tracks
+    @tracks ||= MusixMatch.get_album_tracks(params[:id]).track_list
+    @album_name = @tracks.first.album_name
+    render layout: false
+  end
+end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,5 +1,5 @@
 class ArtistsController < ApplicationController
   def albums
-    @results = MusixMatch.get_artist_albums(params[:id]).album_list
+    @albums = MusixMatch.get_artist_albums(params[:id]).album_list
   end
 end

--- a/app/helpers/time_helper.rb
+++ b/app/helpers/time_helper.rb
@@ -1,0 +1,5 @@
+module TimeHelper
+  def time_in_seconds_and_minutes integer
+    Time.at(integer).utc.strftime "%M:%S"
+  end
+end

--- a/app/views/albums/tracks.html.erb
+++ b/app/views/albums/tracks.html.erb
@@ -1,0 +1,22 @@
+<table class="table table-hover">
+  <thead>
+    <tr>
+      <th colspan="2" class="album-title">
+        <%= @album_name %>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @tracks.each do |track| %>
+      <tr>
+        <td>
+          <img src="<%= track.album_coverart_100x100 %>" width="50px" height="50px">
+          <div class="track-details">
+            <b><%= track.track_name %></b><br />
+            <small><%= time_in_seconds_and_minutes(track.track_length) %></small>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/artists/albums.html.erb
+++ b/app/views/artists/albums.html.erb
@@ -1,4 +1,4 @@
-<% if @results.any? %>
+<% if @albums.any? %>
 <div class="albums-header">
   <a href="<%= request.referrer%>">
     <span class="back-arrow glyphicon glyphicon-menu-left" aria-hidden="true"></span>
@@ -7,21 +7,14 @@
 </div>
 <div id="album-coverflow">
   <ul>
-    <% @results.each do |result| %>
-      <li>
-        <img src="<%= result.album_coverart_100x100 %>">
+    <% @albums.each do |album| %>
+      <li data-tracks-path="/albums/<%= album.album_id %>">
+        <img src="<%= album.album_coverart_100x100 %>">
       </li>
     <% end %>
   </ul>
 </div>
-<div class="table-responsive">
-  <table class="table table-striped">
-    <tbody>
-      <tr>
-        <td></td>
-        <td></td>
-      </tr>
-  </table>
+<div id="album-tracks" class="table-responsive">
 </div>
 <% else %>
   <div class="text-center">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <body>
     <%= render 'layouts/main_nav' %>
     <div class="container-fluid">
-      <div class="row Absolute-Center is-Responsive">
+      <div class="row absolute-center is-responsive">
         <%= yield %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   root "search#index"
   get "search", to: "search#results"
   get "artists/:id", to: "artists#albums"
-  get "artists/:id/albums/:album_id", to: "artists#album_tracks"
+  get "albums/:id", to: "albums#tracks"
 end


### PR DESCRIPTION
# Synopsis

As a user I would like to see the tracks for an album I select
# Included
- Created an HTML endpoint to return tracks from a specified album (JSON request is made via MusixMatch GEM)
- Updated flipster to make a callback each time the album is changed to render the appropriate tracks via ajax
- Updated flipster to load the default selected album tracks when the page is loaded
- Updated styles to more accurately match the RadioFlag design
