### PR TITLE
Add default message and purchase placeholder text

### DIFF
--- a/app/assets/stylesheets/albums.scss
+++ b/app/assets/stylesheets/albums.scss
@@ -23,8 +23,15 @@
 .album-title {
   text-align: left;
   background-color: #D3D3D3;
+  font-weight: 500;
 }
 
 .track-details {
   display: inline-block;
+}
+
+.buy-link {
+  color: #43acfb;
+  float: right;
+  font-weight: 500;
 }

--- a/app/views/albums/tracks.html.erb
+++ b/app/views/albums/tracks.html.erb
@@ -1,20 +1,22 @@
-<table class="table table-hover">
+<table class="table table-hover album-tracks">
   <thead>
     <tr>
       <th colspan="2" class="album-title">
         <%= @album_name %>
+        <span class="buy-link">BUY ALBUM</span>
       </th>
     </tr>
   </thead>
   <tbody>
     <% @tracks.each do |track| %>
       <tr>
-        <td>
+        <td style="border-top: none;">
           <img src="<%= track.album_coverart_100x100 %>" width="50px" height="50px">
           <div class="track-details">
             <b><%= track.track_name %></b><br />
             <small><%= time_in_seconds_and_minutes(track.track_length) %></small>
           </div>
+          <span class="buy-link">BUY</span>
         </td>
       </tr>
     <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,3 @@
+<center>
+  Search for an artist above to begin
+</center>


### PR DESCRIPTION
# Synopsis

Display default text when nothing has been searched for yet and add the "BUY ALBUM" and "BUY" text to the album widget
# Notes

The purchase links are only text for now, as MusixMatch does not have the respective url's to link them to
