### PR TITLE
Add pagination to artist results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,3 +50,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'will_paginate', '~> 3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    will_paginate (3.1.0)
 
 PLATFORMS
   ruby
@@ -183,6 +184,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+  will_paginate (~> 3.1.0)
 
 BUNDLED WITH
    1.12.5

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,0 +1,3 @@
+.pagination-container {
+  float: right;
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,11 +1,15 @@
 class SearchController < ApplicationController
+  require 'will_paginate/array'
+
   def index
     redirect_to action: "results" if artist_name.present?
   end
 
   def results
     set_artist_name_cookie
-    @results = MusixMatch.search_artist({q_artist: artist_name}).artist_list
+    @results = WillPaginate::Collection.create(current_page, per_page, search_response.available) do |pager|
+        pager.replace search_response.artist_list
+    end
   end
 
   private
@@ -18,5 +22,17 @@ class SearchController < ApplicationController
     if params.has_key? :artist_name
       cookies[:artist_name] = params[:artist_name]
     end
+  end
+
+  def current_page
+    params[:page] || 1
+  end
+
+  def per_page
+    10
+  end
+
+  def search_response
+    MusixMatch.search_artist({q_artist: artist_name, page: current_page, page_size: per_page})
   end
 end

--- a/app/views/search/results.html.erb
+++ b/app/views/search/results.html.erb
@@ -15,3 +15,6 @@
       <% end %>
   </table>
 </div>
+<div class="pagination-container">
+  <%= will_paginate @results %>
+</div>


### PR DESCRIPTION
# Synopsis

As a user I would like to see 10 artist results per page and a navigation menu to change the page I am viewing
# Included
- Add will_paginate library
- Update `SearchController` to use will_paginate
- Style search results
